### PR TITLE
conditionally compile unix specific parts

### DIFF
--- a/src/bin/server/instance.rs
+++ b/src/bin/server/instance.rs
@@ -8,6 +8,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::io::ErrorKind;
+#[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -371,8 +372,11 @@ impl RaInstance {
                                 if let Some(code) = status.code() {
                                     details.write_fmt(format_args!(" code {code}")).unwrap();
                                 }
-                                if let Some(signal) = status.signal() {
-                                    details.write_fmt(format_args!(" signal {signal}")).unwrap();
+                                #[cfg(unix)]
+                                {
+                                    if let Some(signal) = status.signal() {
+                                        details.write_fmt(format_args!(" signal {signal}")).unwrap();
+                                    }
                                 }
                                 let pid = instance.pid;
                                 log::error!("[{path} {pid}] child exited {success}{details}");


### PR DESCRIPTION
This allows ra-multiplex to build on Windows. I tested it with VSCode by setting `"rust-analyzer.server.path"` to the `ra-multiplexer.exe` path. It appears to work very well with multiple VSCode windows open on the same project!

---

Some notes from setting it up:

Unless if I manually create a `C:\Users\Michael\AppData\Roaming\ra-multiplex\config\config.toml`

```toml
# config.toml
arg_parsing = true
```

the server eventually logs errors like the following

```
[ERROR] [C:\Program Files\Microsoft VS Code 1972] error reading from stdout: parsing header

    Caused by:
        malformed header, missing \r\n
```

because r-a's VSCode extension also calls `ra-multiplex.exe --version`, but without `arg_parsing = true`, the extension calling the client never receives output (the version), errors like above, then closes that short-lived client.

I haven't made any changes related to this in this pull request (like documentation or different defaults, e.g. always having arg parsing), but I may as well mention if anyone else hits this / before I forget :)