### PR TITLE
Skip shutdown message

### DIFF
--- a/src/bin/server/client.rs
+++ b/src/bin/server/client.rs
@@ -203,7 +203,13 @@ async fn read_client_socket(
                 continue;
             }
         }
-
+        if matches!(json.get("method"), Some(Value::String(method)) if method == "shutdown") {
+            // client requested the server to shut down but other clients might still be connected
+            // instead we disconnect this client to prevent the editor hanging
+            // see https://github.com/pr2502/ra-multiplex/issues/5
+            log::debug!("[{port}] client sent shutdown request, closing connection");
+            break;
+        }
         if let Some(id) = json.get("id") {
             // messages containing an id need the id modified so we can discern which client to send
             // the response to


### PR DESCRIPTION
For issue: #5  
shutdown messages that certain editors produce on exit e.g. `helix`