### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "ra-multiplex"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
b9a14e576f6239563681660b7634ac80183a71e9 bumped the version in `Cargo.toml`, but the corresponding value in `Cargo.lock` wasn't updated, which caused me issues when trying to package this in a Nix expression.