### PR TITLE
Usability improvements

### DIFF
--- a/src/bin/server/instance.rs
+++ b/src/bin/server/instance.rs
@@ -238,7 +238,14 @@ impl RaInstance {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .context("couldn't spawn rust-analyzer")?;
+            .with_context(|| {
+                format!(
+                    "couldn't spawn rust-analyzer with command: `{}{}{}`",
+                    &key.server,
+                    if key.args.is_empty() { "" } else { " " },
+                    key.args.join(" ")
+                )
+            })?;
 
         let pid = child.id().context("child exited early, couldn't get PID")?;
         let stderr = child.stderr.take().unwrap();

--- a/src/bin/server/main.rs
+++ b/src/bin/server/main.rs
@@ -8,8 +8,9 @@
 
 use crate::client::Client;
 use crate::instance::InstanceRegistry;
-use anyhow::{Context, Result};
+use anyhow::{Context, bail, Result};
 use ra_multiplex::config::Config;
+use std::env;
 use tokio::net::TcpListener;
 use tokio::task;
 
@@ -22,6 +23,10 @@ mod lsp;
 async fn main() -> Result<()> {
     let config = Config::load_or_default().await;
     let registry = InstanceRegistry::new().await;
+
+    if env::args().nth(1).is_some() {
+        bail!("`ra-multiplex-server` does not accept any arguments. To configure it, edit config.toml or pass arguments to the `ra-multiplex` client");
+    }
 
     let listener = TcpListener::bind(config.listen).await.context("listen")?;
     loop {


### PR DESCRIPTION
Closes #9 

1. When `ra-multiplex-server` fails to invoke the lsp server, display the attempted command.
2. Error if `ra-multiplex-server` is invoked with the `ra-mux-server` argument. It should only be passed to the `ra-multiplex` client.
3. Add `ra-multiplex-server --help` and `-h`.

I initially added help text for the client, but I removed it because I think `ra-multiplex --help` should proxy to `rust-analyzer --help`. 