### PR TITLE
clippy fixes

### DIFF
--- a/src/bin/server/lsp.rs
+++ b/src/bin/server/lsp.rs
@@ -161,7 +161,7 @@ impl Message {
     }
 
     pub fn as_bytes(&self) -> &[u8] {
-        &*self.bytes
+        &self.bytes
     }
 
     /// construct a message from a serializable value, like JSON
@@ -179,7 +179,7 @@ impl Message {
         writer
             .write_all(format!("Content-Length: {}\r\n\r\n", self.bytes.len()).as_bytes())
             .await?;
-        writer.write_all(&*self.bytes).await?;
+        writer.write_all(&self.bytes).await?;
         writer.flush().await
     }
 }


### PR DESCRIPTION
tiny fix for:

```
    Checking ra-multiplex v0.2.0 (src/ra-multiplex)
warning: deref which would be done by auto-deref
   --> src/bin/server/lsp.rs:164:9
    |
164 |         &*self.bytes
    |         ^^^^^^^^^^^^ help: try this: `&self.bytes`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
    = note: `#[warn(clippy::explicit_auto_deref)]` on by default

warning: deref which would be done by auto-deref
   --> src/bin/server/lsp.rs:182:26
    |
182 |         writer.write_all(&*self.bytes).await?;
    |                          ^^^^^^^^^^^^ help: try this: `&self.bytes`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

warning: `ra-multiplex` (bin "ra-multiplex-server") generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.35s
```