### PR TITLE
Slightly improve error message for protocol version mismatch

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -38,8 +38,12 @@ impl Init {
             .context("read proto init")?;
         buffer.pop(); // remove trailing '\0'
 
-        let proto_init: Self = serde_json::from_slice(buffer).context("invalid proto init")?;
-        ensure!(proto_init.check_version(), "invalid protocol version");
+        let proto_init: Self =
+            serde_json::from_slice(buffer).context("invalid ra-multiplex proto init")?;
+        ensure!(
+            proto_init.check_version(),
+            "ra-multiplex client protocol different version from the server"
+        );
 
         Ok(proto_init)
     }


### PR DESCRIPTION
HI there, love this crate. Thanks for building it!

Just went down the rabbithole of changing my rustc/rust-analyzer versions because I didn't realize this error was coming from ra-multiplex. I thought maybe making it more explicit might save some future developer some time :)