### PR TITLE
Use native LSP init message for handshake

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use ra_multiplex::config::Config;
 use ra_multiplex::proto;
+use serde_json::{Map, Value};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::{io, task};
@@ -8,20 +9,26 @@ use tokio::{io, task};
 pub async fn main(server_path: String, server_args: Vec<String>) -> Result<()> {
     let config = Config::load_or_default().await;
 
-    let proto_init = proto::Init::new(server_path, server_args);
-    let mut proto_init = serde_json::to_vec(&proto_init).context("sending proto init")?;
-    proto_init.push(b'\0');
-
     let stream = TcpStream::connect(config.connect)
         .await
         .context("connect")?;
     let (mut read_stream, mut write_stream) = stream.into_split();
 
-    write_stream
-        .write_all(&proto_init)
-        .await
-        .context("sending proto init")?;
-    drop(proto_init);
+    {
+        let mut buf = Vec::new();
+        let mut r = tokio::io::BufReader::new(read_stream);
+        let (mut json, _) = ra_multiplex::lsp::read_message(&mut r, &mut buf)
+            .await?
+            .context("received invalid InitializeRequest")?;
+
+        let proto_init = proto::Init::new(server_path, server_args);
+        inject_options_into_initialization_request(&mut json, proto_init)?;
+
+        write_stream.write_all(&serde_json::to_vec(&json)?).await?;
+
+        // Revert read_stream to its original state.
+        read_stream = r.into_inner();
+    }
 
     let t1 = task::spawn(async move {
         io::copy(&mut read_stream, &mut io::stdout())
@@ -38,5 +45,49 @@ pub async fn main(server_path: String, server_args: Vec<String>) -> Result<()> {
         res = t2 => res,
     }
     .context("join")??;
+    Ok(())
+}
+
+fn inject_options_into_initialization_request(
+    request: &mut Map<String, Value>,
+    opts: proto::Init,
+) -> anyhow::Result<()> {
+    if !matches!(request.get("method"), Some(Value::String(method)) if method == "initialize") {
+        bail!("first client message was not InitializeRequest");
+    }
+
+    let params = request
+        .get_mut("params")
+        .context("initialization request should contain params")?
+        .as_object_mut()
+        .context("initialization request params must be an object")?;
+
+    let init_options = match params.get_mut("initializationOptions") {
+        Some(opts) => opts
+            .as_object_mut()
+            // Technically it can be anything. I don't think any LSP uses a non-object here.
+            .context("initializationOptions should be an object")?,
+        None => {
+            let opts = Map::new();
+            params.insert(String::from("initializationOptions"), Value::from(opts));
+            params
+                .get_mut("initializationOptions")
+                .expect("initializationOptions must be present")
+                .as_object_mut()
+                .expect("initializationOptions must be an object")
+        }
+    };
+
+    let (cwd, server, args) = (opts.cwd, opts.server, opts.args);
+
+    let multiplex_opts = {
+        let mut m = Map::new();
+        m.insert(String::from("cwd"), Value::from(cwd));
+        m.insert(String::from("server"), Value::from(server));
+        m.insert(String::from("args"), Value::from(args));
+        m
+    };
+    init_options.insert(String::from("raMultiplex"), Value::from(multiplex_opts));
+
     Ok(())
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,9 +1,8 @@
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::env;
-use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Init {
@@ -82,28 +81,6 @@ impl Init {
             server: server.unwrap_or("rust-analyzer".to_string()),
             args,
         })
-    }
-
-    // XXX: unused
-    pub async fn from_reader<R: AsyncBufRead + Unpin>(
-        buffer: &mut Vec<u8>,
-        mut reader: R,
-    ) -> Result<Self> {
-        buffer.clear();
-        reader
-            .read_until(b'\0', &mut *buffer)
-            .await
-            .context("read proto init")?;
-        buffer.pop(); // remove trailing '\0'
-
-        let proto_init: Self =
-            serde_json::from_slice(buffer).context("invalid ra-multiplex proto init")?;
-        ensure!(
-            proto_init.check_version(),
-            "ra-multiplex client protocol version differs from server version"
-        );
-
-        Ok(proto_init)
     }
 
     /// returns true if the version matches

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -27,7 +27,7 @@ impl Init {
     /// Create an `Init` instance from a raw initialization request.
     ///
     /// Removes the `raMultiplex` objects from `initializationOptions` if it is present.
-    pub fn from_json(json: &mut serde_json::Map<String, Value>) -> Result<Self> {
+    pub fn from_init_request(json: &mut serde_json::Map<String, Value>) -> Result<Self> {
         let mut server = Option::<String>::None;
         let mut args = Vec::new();
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -6,8 +6,6 @@ use std::env;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Init {
-    proto: String,
-    version: String,
     pub cwd: String,
     pub server: String,
     pub args: Vec<String>,
@@ -16,8 +14,6 @@ pub struct Init {
 impl Init {
     pub fn new(server: String, args: Vec<String>) -> Init {
         Init {
-            proto: env!("CARGO_PKG_NAME").to_owned(),
-            version: env!("CARGO_PKG_VERSION").to_owned(),
             cwd: env::current_dir()
                 .expect("cannot access current directory")
                 .to_str()
@@ -73,18 +69,9 @@ impl Init {
             .to_owned();
 
         Ok(Init {
-            // FIXME: this values here don't really make sense, but need to figure out what to do
-            // with these fields
-            proto: env!("CARGO_PKG_NAME").to_string(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
             cwd,
             server: server.unwrap_or("rust-analyzer".to_string()),
             args,
         })
-    }
-
-    /// returns true if the version matches
-    pub fn check_version(&self) -> bool {
-        self.proto == env!("CARGO_PKG_NAME") && self.version == env!("CARGO_PKG_VERSION")
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,9 +1,10 @@
 use anyhow::{ensure, Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::env;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Init {
     proto: String,
     version: String,
@@ -27,6 +28,50 @@ impl Init {
         }
     }
 
+    pub fn from_json(json: &serde_json::Map<String, Value>) -> Result<Self> {
+        let params = json
+            .get("params")
+            .context("expected params in initialization message")?;
+        let init_options = params
+            .get("initializationOptions")
+            .context("expected initializationOptions in params")?;
+
+        let mut server = None;
+        let mut args = Vec::new();
+        if let Some(config) = init_options.get("raMultiplex") {
+            server = config.get("server").and_then(|s| s.as_str());
+            if let Some(values) = config.get("args").and_then(|s| s.as_array()) {
+                for value in values {
+                    args.push(
+                        value
+                            .as_str()
+                            .context("expected args to be an array of strings")?
+                            .to_owned(),
+                    )
+                }
+            }
+        };
+
+        // TODO: this is deprecated and may be absent; try newer fields too.
+        let cwd = params
+            .get("rootPath")
+            .context("expected rootPath in init message")?
+            .as_str()
+            .context("expected rootPath to be a String")?
+            .to_owned();
+
+        Ok(Init {
+            // FIXME: this values here don't really make sense, but need to figure out what to do
+            // with these fields
+            proto: env!("CARGO_PKG_NAME").to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            cwd,
+            server: server.unwrap_or("rust-analyzer").to_string(),
+            args,
+        })
+    }
+
+    // XXX: unused
     pub async fn from_reader<R: AsyncBufRead + Unpin>(
         buffer: &mut Vec<u8>,
         mut reader: R,

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -54,7 +54,7 @@ impl Client {
             bail!("first client message was not InitializeRequest");
         }
 
-        let proto_init = proto::Init::from_json(&mut json)?;
+        let proto_init = proto::Init::from_init_request(&mut json)?;
 
         log::debug!("[{port}] recv InitializeRequest");
         // this is an initialize request, it's special because it cannot be sent twice or

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -54,7 +54,7 @@ impl Client {
             bail!("first client message was not InitializeRequest");
         }
 
-        let proto_init = proto::Init::from_json(&json)?;
+        let proto_init = proto::Init::from_json(&mut json)?;
 
         log::debug!("[{port}] recv InitializeRequest");
         // this is an initialize request, it's special because it cannot be sent twice or


### PR DESCRIPTION
This change updates the server to read its configuration options from the initialization request's `initializationOptions.raMultiplex` field. `initializationOptions` is usually reserved for LSP-specific configuration, so this seemed like a good fit.

The workspace root path used is the same one as resolved by the client and specified in the initialization request (although the field is deprecated and I still need to handle using the new one if the old one is absent).

I've tested this by configuring neovim to connect to `ra-multiplex-server` directly:

    cmd = vim.lsp.rpc.connect('127.0.0.1', 27631),
    init_options = {
      raMultiplex = {
        server = "rust-analyzer"
      }
    },

It connects and works. Setting another `server` value here works as intended too. This allows configuring a client to pass a different server depending on filetype too (it should also be doable in a generic way, instead of duplicating the configuration for each filetype/server).

There's still some missing work:

- [ ] The client portion of the changes need to be done (and these will be a bit more work). Essentially, I'd want the client to encapsulate its configuration into the initialization request. I mostly want some feedback on the approach before addressing this.
- [x] I'm not sure what to do about the protocol and version fields in the init message, I think that it would make sense to drop them. _Edit: I've dropped them._
- [x] `Init::from_reader` is now unused, so I think it should be dropped too.
- [x] The `initializationOptions.raMultiplex` should be removed from the request before forwarding it to the server (just in case some server is picky about unknown fields).

Fixes: https://github.com/pr2502/ra-multiplex/issues/20