### PR TITLE
Update README for Unified Binary Usage

### DIFF
--- a/ra-mux.service
+++ b/ra-mux.service
@@ -3,7 +3,7 @@ Description=Rust analyzer multiplex server
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/ra-multiplex-server
+ExecStart=/usr/local/bin/ra-multiplex server
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This PR updates the README.md file to reflect the latest changes in the usage of the `ra-multiplex` tool. Instead of using two separate binaries, the tool now uses a single binary that can be run in either client or server mode.

Updates in this PR include:
- Removed references to the old binary `ra-multiplex-server`
- Added instructions for using `ra-multiplex` in client and server modes
- Updated examples to use the single binary
- Adjusted configuration instructions for other LSP servers to reflect the single binary usage

This documentation update ensures that users are informed about the latest usage practices of `ra-multiplex`, providing a more accurate and efficient user experience.
