### PR TITLE
Allow specifying client/server through env vars

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,28 @@
-use clap::{Args, Parser, Subcommand};
+use std::env;
+
+use clap::{Parser, Subcommand};
 
 mod client;
 mod server;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author,
+    version,
+    about,
+    after_help = "\
+The use of the `client` and `server` subcommands can be forced through
+`RA_MUX_RUN_CLIENT=1` and `RA_MUX_RUN_SERVER=true` or any other non-falsey
+value respectively. When the subcommand is set this way any args are treated as
+though they are passed to this subcommand."
+)]
 struct Cli {
     /// No command defaults to client
     #[command(subcommand)]
     command: Cmd,
 }
 
-#[derive(Args, Debug, Default)]
+#[derive(Parser, Debug, Default)]
 struct ClientArgs {
     /// Path to the LSP server executable
     #[arg(
@@ -26,7 +37,7 @@ struct ClientArgs {
     server_args: Vec<String>,
 }
 
-#[derive(Args, Debug)]
+#[derive(Parser, Debug)]
 struct ServerArgs {
     /// Dump all communication with the client
     #[arg(long)]
@@ -48,11 +59,52 @@ impl Default for Cmd {
     }
 }
 
+fn maybe_var_truthy(var: &str) -> anyhow::Result<Option<bool>> {
+    let maybe_bool = match env::var(var) {
+        // Matches the truthy values from `clap::builder::BoolishValueParser`
+        Ok(val) => Some(["y", "yes", "t", "true", "on", "1"].contains(&&*val)),
+        Err(env::VarError::NotPresent) => None,
+        Err(env::VarError::NotUnicode(val)) => {
+            let lossy_val = val.to_string_lossy().into_owned();
+            anyhow::bail!(
+                "env var '{}' contained invalid unicode '{}'",
+                var,
+                lossy_val
+            )
+        }
+    };
+
+    Ok(maybe_bool)
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
+    const CLIENT_ENV_VAR: &str = "RA_MUX_RUN_CLIENT";
+    const SERVER_ENV_VAR: &str = "RA_MUX_RUN_SERVER";
 
-    match cli.command {
+    // Allow for running either the client or server through env vars, so that users can run them
+    // from the unified binary through setting `rust-analyzer.server.extraEnv`
+    let force_run_client = Some(true) == maybe_var_truthy(CLIENT_ENV_VAR)?;
+    let force_run_server = Some(true) == maybe_var_truthy(SERVER_ENV_VAR)?;
+
+    let command = match (force_run_client, force_run_server) {
+        (true, true) => anyhow::bail!(
+            "Only one of {} and {} can be set truthy, but both are",
+            CLIENT_ENV_VAR,
+            SERVER_ENV_VAR
+        ),
+        (true, false) => {
+            let args = ClientArgs::parse();
+            Cmd::Client(args)
+        }
+        (false, true) => {
+            let args = ServerArgs::parse();
+            Cmd::Server(args)
+        }
+        (false, false) => Cli::parse().command,
+    };
+
+    match command {
         Cmd::Client(args) => client::main(args.server_path, args.server_args).await,
         Cmd::Server(args) => server::main(args.dump).await,
     }


### PR DESCRIPTION
The switch to the unified binary caused some issues (unless I'm missing something) when it comes to running the server through coc.nvim. The lack of something like `rust-analyzer.server.extraArgs` makes it impossible to run specifically the server or client since there is no way to pass the appropriate subcommand (without resorting to things like wrapper scripts)

This change remedies that issue by allowing for running the client and server by setting the `RA_MUX_RUN_CLIENT` and `RA_MUX_RUN_SERVER` env vars respectively to truthy values. This makes `ra-mux` workable with a coc config like (related #28)

```json
{
	"rust-analyzer.server.path": "/usr/local/bin/ra-multiplex",
	"rust-analyzer.server.extraEnv": {
		"RA_MUX_RUN_CLIENT": true,
	}
}
```