### PR TITLE
Handle some server requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -414,12 +414,12 @@ async fn output_task(
                     // Drop the message
                 }
                 _ => {
-                    debug!(message = ?res, "unexpected client response");
+                    debug!(?res, "unexpected client response");
                 }
             },
 
             Message::ResponseError(res) => {
-                warn!(message = ?res, "client response error");
+                warn!(?res, "client responded with error");
             }
 
             Message::Notification(notif) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -388,12 +388,9 @@ async fn output_task(
                 // Instead we disconnect this client to prevent the editor hanging
                 // see <https://github.com/pr2502/ra-multiplex/issues/5>.
                 info!("client sent shutdown request, sending a response and closing connection");
+
                 // <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown>
-                let res = ResponseSuccess {
-                    jsonrpc: Version,
-                    result: Value::Null,
-                    id: req.id,
-                };
+                let res = ResponseSuccess::null(req.id);
                 // Ignoring error because we would've closed the connection regardless
                 let _ = close_tx.send(res.into()).await;
                 break;

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -86,14 +86,20 @@ pub async fn status(json: bool) -> Result<()> {
     }
 
     for instance in res.instances {
-        println!("- Instance pid {}", instance.pid);
+        println!("- Instance");
+        println!("  pid: {}", instance.pid);
         println!("  server: {:?} {:?}", instance.server, instance.args);
         println!("  path: {:?}", instance.workspace_root);
         let now = time::OffsetDateTime::now_utc().unix_timestamp();
         println!("  last used: {}s ago", now - instance.last_used);
+        println!("  registered dynamic capabilities:");
+        for cap in instance.registered_dyn_capabilities {
+            println!("    - {}", cap);
+        }
         println!("  clients:");
         for client in instance.clients {
-            println!("  - Client port {}", client.port);
+            println!("    - Client");
+            println!("      port: {}", client.port);
         }
     }
     Ok(())

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -614,6 +614,14 @@ async fn stdout_task(instance: Arc<Instance>, mut reader: LspReader<BufReader<Ch
             }
 
             Message::Request(req) => {
+                // Unimplemented server -> client requests I've found in the LSP Spec.
+                // TODO workspace/workspaceFolders request
+                // TODO workspace/applyEdit request
+                // TODO workspace/codeLens/refresh request
+                // TODO workspace/semanticTokens/refresh request
+                // TODO workspace/inlayHint/refresh request
+                // TODO workspace/inlineValue/refresh request
+                // TODO workspace/diagnostic/refresh request
                 debug!(message = ?req, "ignoring unknown server request");
             }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -147,18 +147,28 @@ impl Instance {
     }
 
     pub fn get_status(&self) -> ext::Instance {
+        let clients = self
+            .clients
+            .blocking_lock()
+            .values()
+            .map(|client| client.get_status())
+            .collect();
+
+        let registered_dyn_capabilities = self
+            .dynamic_capabilities
+            .blocking_lock()
+            .values()
+            .map(|reg| reg.method.clone())
+            .collect();
+
         ext::Instance {
             pid: self.pid,
             server: self.key.server.clone(),
             args: self.key.args.clone(),
             workspace_root: self.key.workspace_root.clone(),
             last_used: self.last_used.load(Ordering::Relaxed),
-            clients: self
-                .clients
-                .blocking_lock()
-                .values()
-                .map(|client| client.get_status())
-                .collect(),
+            clients,
+            registered_dyn_capabilities,
         }
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -111,3 +111,37 @@ pub struct ServerInfo {
     name: String,
     version: Option<String>,
 }
+
+/// Params for `client/registerCapability` request
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistrationParams {
+    pub registrations: Vec<Registration>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Registration {
+    pub id: String,
+    pub method: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub register_options: Option<serde_json::Value>,
+}
+
+/// Params for `client/unregisterCapability` request
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UnregistrationParams {
+    /// This is a typo in the LSP 3.xx spec, we need to replicate it until they
+    /// upgrade the protocol version.
+    #[serde(rename = "unregisterations")]
+    pub unregistrations: Vec<Unregistration>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Unregistration {
+    pub id: String,
+    pub method: String,
+}

--- a/src/lsp/ext.rs
+++ b/src/lsp/ext.rs
@@ -156,6 +156,7 @@ pub struct Instance {
     pub server: String,
     pub args: Vec<String>,
     pub workspace_root: String,
+    pub registered_dyn_capabilities: Vec<String>,
     pub last_used: i64,
     pub clients: Vec<Client>,
 }

--- a/src/lsp/jsonrpc.rs
+++ b/src/lsp/jsonrpc.rs
@@ -53,6 +53,17 @@ pub struct ResponseSuccess {
     pub id: RequestId,
 }
 
+impl ResponseSuccess {
+    /// Creates a new response with `null` result
+    pub fn null(id: RequestId) -> Self {
+        ResponseSuccess {
+            jsonrpc: Version,
+            result: serde_json::Value::Null,
+            id,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Error {

--- a/src/lsp/jsonrpc.rs
+++ b/src/lsp/jsonrpc.rs
@@ -150,11 +150,21 @@ impl From<ResponseError> for Message {
     }
 }
 
-impl fmt::Debug for Message {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let json = serde_json::to_string(self).expect("BUG: invalid message");
-        f.write_str(&json)
-    }
+macro_rules! impl_json_debug {
+    ( $($type:ty),* $(,)? ) => {
+        $(
+            impl fmt::Debug for $type {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    let json = serde_json::to_string(self).expect("BUG: invalid message");
+                    f.write_str(&json)
+                }
+            }
+        )*
+    };
+}
+
+impl_json_debug! {
+    Message, Request, Notification, ResponseSuccess, ResponseError,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Supersedes #26. This handles some of the server -> client requests explicitly in ways which should be safe for that particular request and continues to ignore the rest like before.

So far I've implemented all requests I've noticed while using helix with rust-analyzer. I'll try more editors and language servers I'm familiar with when I have time. If anyone wants to try it with their editor please reply with your findings :)