### PR TITLE
Allow passing environment to language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+- configuration option `pass_environment` which specifies a list of env var names to be passed from ra-multiplex client proxy to the spawned language server (rust-analyzer)
+
+
 ## [v0.2.4] - 2024-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ connect = ["127.0.0.1", 27631] # same as `listen`
 # is documented in the `env_logger` documentation here:
 # <https://docs.rs/env_logger/0.9.0/env_logger/index.html#enabling-logging>
 log_filters = "info"
+
+# environemnt variable names passed from `ra-multiplex client` to the server
+#
+# by default no variables are passed. and all servers are spawned in
+# the same environment as the `ra-multiplex server` is. when a name like
+# "LD_LIBRARY_PATH" is specifified the proxy reads the variable value from its
+# environment and passes it to the server which then passes it on to the server
+# executable.
+#
+# if "PATH" is specified here then the PATH from the client environment is
+# going to be used for looking up a relative `--server-path`.
+pass_environment = []
 ```
 
 

--- a/defaults.toml
+++ b/defaults.toml
@@ -3,3 +3,4 @@ gc_interval = 10
 listen = ["127.0.0.1", 27631]
 connect = ["127.0.0.1", 27631]
 log_filters = "info"
+pass_environment = []

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
 
@@ -31,6 +32,10 @@ mod default {
 
     pub fn log_filters() -> String {
         "info".to_owned()
+    }
+
+    pub fn pass_environment() -> BTreeSet<String> {
+        BTreeSet::new()
     }
 }
 
@@ -96,6 +101,9 @@ pub struct Config {
 
     #[serde(default = "default::log_filters")]
     pub log_filters: String,
+
+    #[serde(default = "default::pass_environment")]
+    pub pass_environment: BTreeSet<String>,
 }
 
 #[cfg(test)]
@@ -121,6 +129,7 @@ impl Default for Config {
             listen: default::listen(),
             connect: default::connect(),
             log_filters: default::log_filters(),
+            pass_environment: default::pass_environment(),
         }
     }
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -86,6 +86,12 @@ pub async fn status(config: &Config, json: bool) -> Result<()> {
         println!("- Instance");
         println!("  pid: {}", instance.pid);
         println!("  server: {:?} {:?}", instance.server, instance.args);
+        if !instance.env.is_empty() {
+            println!("  server env:");
+            for (key, val) in instance.env {
+                println!("    {key} = {val}");
+            }
+        }
         println!("  path: {:?}", instance.workspace_root);
         let now = time::OffsetDateTime::now_utc().unix_timestamp();
         println!("  last used: {}s ago", now - instance.last_used);

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::ErrorKind;
 use std::ops::Deref;
 use std::path::Path;
@@ -31,6 +31,7 @@ use crate::lsp::{self, ext};
 pub struct InstanceKey {
     pub server: String,
     pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
     pub workspace_root: String,
 }
 
@@ -310,6 +311,7 @@ impl Instance {
             pid: self.pid,
             server: self.key.server.clone(),
             args: self.key.args.clone(),
+            env: self.key.env.clone(),
             workspace_root: self.key.workspace_root.clone(),
             last_used: self.last_used.load(Ordering::Relaxed),
             clients,
@@ -422,6 +424,7 @@ async fn spawn(
 ) -> Result<Arc<Instance>> {
     let mut child = Command::new(&key.server)
         .args(&key.args)
+        .envs(&key.env)
         .current_dir(&key.workspace_root)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src/lsp/ext.rs
+++ b/src/lsp/ext.rs
@@ -1,5 +1,6 @@
 //! LSP-mux (ra-multiplex) specific protocol extensions
 
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use anyhow::{bail, Context, Result};
@@ -123,9 +124,14 @@ pub enum Request {
         server: String,
 
         /// Arguments which will be passed to the language server, defaults to an
-        /// empty list if omited.
+        /// empty list if omitted.
         #[serde(default = "Vec::new")]
         args: Vec<String>,
+
+        /// Environment variables which will be set for the language server,
+        /// defaults to an empty set if omitted.
+        #[serde(default = "BTreeMap::new", skip_serializing_if = "BTreeMap::is_empty")]
+        env: BTreeMap<String, String>,
 
         /// Current working directory of the proxy command. This is only used as
         /// fallback if the client doesn't provide any workspace root.
@@ -159,6 +165,7 @@ pub struct Instance {
     pub pid: u32,
     pub server: String,
     pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
     pub workspace_root: String,
     pub registered_dyn_capabilities: Vec<String>,
     pub last_used: i64,


### PR DESCRIPTION
This allows to both forwarding environment variables set by the LSP client (editor) via the LSP proxy (`ra-multiplex client`) to the LSP server. And also allows directly setting environment variables for LSP clients which are able to connect to `ra-multiplex` directly via TCP.

Allows user to add `pass_environment = ["PATH"]` to `~/.config/ra-multiplex/config.toml`, resolves #27 

cc @IndianBoy42 if this is something you're still interested in.