### PR TITLE
improve the CI linting steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,19 @@ jobs:
     name: Rust project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-features -- -D warnings
+
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
+
       - name: Build
         run: cargo build --locked
+
       - name: Test
         run: cargo test --locked
-      - name: Clippy
-        run: cargo clippy
-      - name: Rustfmt
-        run: cargo fmt --check


### PR DESCRIPTION
Catch more errors/warnings. The main branch has those warnings for example
```
error: field `content_type` is never read
  --> src/lsp/transport.rs:30:9
   |
28 | pub struct Header {
   |            ------ field in this struct
29 |     pub content_length: usize,
30 |     pub content_type: Option<String>,
   |         ^^^^^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`

error: field `0` is never read
  --> src/socketwrapper.rs:17:8
   |
17 |     Ip(net::SocketAddr),
   |     -- ^^^^^^^^^^^^^^^
   |     |
   |     field in this variant
   |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
17 |     Ip(()),
   |        ~~

error: field `0` is never read
  --> src/socketwrapper.rs:19:10
   |
19 |     Unix(tokio::net::unix::SocketAddr),
   |     ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     field in this variant
   |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
19 |     Unix(()),
   |          ~~

error: could not compile `ra-multiplex` (lib) due to 3 previous errors
111