### PR TITLE
fix: `init_options` is no longer supported in the rust-analyzer lsp config

### DIFF
--- a/examples/neovim/init.lua
+++ b/examples/neovim/init.lua
@@ -2,11 +2,13 @@ require'lspconfig'.rust_analyzer.setup {
   cmd = vim.lsp.rpc.connect("127.0.0.1", 27631),
   -- When using unix domain sockets, use something like:
   --cmd = vim.lsp.rpc.connect("/path/to/ra-multiplex.sock"),
-  init_options = {
-    lspMux = {
-      version = "1",
-      method = "connect",
-      server = "rust-analyzer",
+  settings = {
+    ["rust-analyzer"] = {
+      lspMux = {
+        version = "1",
+        method = "connect",
+        server = "rust-analyzer",
+      },
     },
   },
 }


### PR DESCRIPTION
[As lspconfig states in the doc](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rust_analyzer), we need to pass the additional `lspMux` in the settings instead. This PR tries to fix the example config for neovim LSP. 