### PR TITLE
Update neovim example when using UDS

### DIFF
--- a/examples/neovim/init.lua
+++ b/examples/neovim/init.lua
@@ -1,7 +1,7 @@
 require'lspconfig'.rust_analyzer.setup {
   cmd = vim.lsp.rpc.connect("127.0.0.1", 27631),
   -- When using unix domain sockets, use something like:
-  --cmd = vim.lsp.rpc.domain_socket_connect("/path/to/ra-multiplex.sock"),
+  --cmd = vim.lsp.rpc.connect("/path/to/ra-multiplex.sock"),
   init_options = {
     lspMux = {
       version = "1",


### PR DESCRIPTION
The provisional API for supporting UDS LSP connections for neovim was to provide a function vim.lsp.rpc.domain_socket_connect but neovim/neovim#28398 changed this to just be implemented using the regular vim.lsp.rpc.connect. This commit updates the neovim example to follow suit.