### PR TITLE
fix serde & serde_derive Deserialize name conflict

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
 use serde::de::{Error, Unexpected};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize as _, Deserializer};
 use serde_derive::{Deserialize, Serialize};
 
 mod default {


### PR DESCRIPTION
config.rs:11:20
   |
10 | use serde::{Deserialize, Deserializer};
   |             ----------- previous import of the macro `Deserialize` here
11 | use serde_derive::{Deserialize, Serialize};
   |                    ^^^^^^^^^^^--
   |                    |
   |                    `Deserialize` reimported here
   |                    help: remove unnecessary import
   |
   = note: `Deserialize` must be defined only once in the macro namespace of this module

Compile failed with rustc 1.87.0