### PR TITLE
Tidy up async behaviour

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pin-project-lite = "0.2.14"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.78"
 time = "0.3.30"
-tokio = { version = "1.37.0", features = ["fs", "io-std", "io-util", "macros", "net", "parking_lot", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.37.0", features = ["fs", "io-std", "io-util", "macros", "net", "parking_lot", "process", "rt", "sync", "time"] }
 toml = "0.5.8"
 tracing = "0.1.39"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,9 +110,7 @@ async fn status(
     instance_map: Arc<Mutex<InstanceMap>>,
     mut writer: LspWriter<OwnedWriteHalf>,
 ) -> Result<()> {
-    let status = task::spawn_blocking(move || instance_map.blocking_lock().get_status())
-        .await
-        .unwrap();
+    let status = instance_map.lock().await.get_status();
     writer
         .write_message(&Message::ResponseSuccess(ResponseSuccess {
             jsonrpc: Version,

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,7 +110,7 @@ async fn status(
     instance_map: Arc<Mutex<InstanceMap>>,
     mut writer: LspWriter<OwnedWriteHalf>,
 ) -> Result<()> {
-    let status = instance_map.lock().await.get_status();
+    let status = instance_map.lock().await.get_status().await;
     writer
         .write_message(&Message::ResponseSuccess(ResponseSuccess {
             jsonrpc: Version,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ enum Cmd {
     Reload {},
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 


### PR DESCRIPTION
- Disable multi-threaded rt; we don't need additional threads.
- Avoid blocking locks; we can just use async locks.